### PR TITLE
Add end year in sub label for stocks in GIDD

### DIFF
--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -227,3 +227,21 @@ export function prepareUrl(url: string, params: UrlParams): string {
     }
     return url;
 }
+
+export function getMaximum<T>(
+    list: T[] | undefined,
+    comparator: (item1: T, item2: T) => number,
+): T | undefined {
+    if (!list || list.length < 1) {
+        return undefined;
+    }
+    return list.reduce((acc: T, item: T) => {
+        if (!item) {
+            return acc;
+        }
+        if (comparator(item, acc) > 0) {
+            return item;
+        }
+        return acc;
+    }, list[0]);
+}

--- a/app/views/CountryProfile/index.tsx
+++ b/app/views/CountryProfile/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@apollo/client';
 import {
     _cs,
+    compareNumber,
     isNotDefined,
 } from '@togglecorp/fujs';
 
@@ -33,6 +34,7 @@ import FigureAnalysis from '#components/FigureAnalysis';
 
 import {
     replaceWithDrupalEndpoint,
+    getMaximum,
 } from '#utils/common';
 
 import IduWidget from '../IduWidget';
@@ -164,7 +166,13 @@ function CountryProfile(props: Props) {
                     overviews,
                 } = response.countryProfile;
                 if (overviews && overviews.length > 0) {
-                    setOverviewActiveYear(overviews[0].year.toString());
+                    const latestYear = getMaximum(
+                        overviews,
+                        (overview1, overview2) => compareNumber(overview1.year, overview2.year),
+                    );
+                    if (latestYear) {
+                        setOverviewActiveYear(latestYear.year.toString());
+                    }
                 }
             },
         },

--- a/app/views/CountryProfile/styles.css
+++ b/app/views/CountryProfile/styles.css
@@ -77,7 +77,6 @@
                     .tab-list {
                         display: flex;
                         flex-direction: column;
-                        flex-grow: 1;
                         flex-shrink: 0;
                         background-color: transparent;
                         width: 12rem;

--- a/app/views/Gidd/index.tsx
+++ b/app/views/Gidd/index.tsx
@@ -94,6 +94,13 @@ function getCountryCountSubLabel(count = 0) {
     return `In ${count} countries and territories`;
 }
 
+function getCountryStockCountSubLabel(count = 0, year: number) {
+    if (count === 1) {
+        return `In 1 country and territory as of ${year}`;
+    }
+    return `In ${count} countries and territories as of ${year}`;
+}
+
 const mainText = 'IDMC Data Portal enables you to explore, filter and sort our data to produce your own graphs and tables. You can also access and export the data used to generate these visualisations.';
 const downloadText = 'You can export your data, either the full dataset or the result of your query in an Excel format which includes the metadata and copyrights.';
 const flowDetails = 'The internal displacements figure refers to the number of forced movements of people within the borders of their country recorded during the year. Figures may include individuals who have been displaced more than once.';
@@ -1174,8 +1181,9 @@ function Gidd(props: Props) {
                                 <NumberBlock
                                     label="Total"
                                     size="large"
-                                    subLabel={getCountryCountSubLabel(
+                                    subLabel={getCountryStockCountSubLabel(
                                         combinedStats?.totalDisplacementCountries,
+                                        timeRange[1],
                                     )}
                                     value={combinedStats?.totalDisplacementsRounded}
                                 />
@@ -1186,8 +1194,9 @@ function Gidd(props: Props) {
                                         label="Total by conflict and violence"
                                         variant="conflict"
                                         size={displacementCause ? 'large' : 'medium'}
-                                        subLabel={getCountryCountSubLabel(
+                                        subLabel={getCountryStockCountSubLabel(
                                             conflictStats?.totalDisplacementCountries,
+                                            timeRange[1],
                                         )}
                                         value={conflictStats?.totalDisplacementsRounded}
                                     />
@@ -1197,8 +1206,9 @@ function Gidd(props: Props) {
                                         label="Total by disasters"
                                         size={displacementCause ? 'large' : 'medium'}
                                         variant="disaster"
-                                        subLabel={getCountryCountSubLabel(
+                                        subLabel={getCountryStockCountSubLabel(
                                             disasterStats?.totalDisplacementCountries,
+                                            timeRange[1],
                                         )}
                                         value={disasterStats?.totalDisplacementsRounded}
                                     />


### PR DESCRIPTION
## Changes

* Add end year in sub label for stocks in GIDD
* Select latest year by default in country profile overview section

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers