### PR TITLE
Pass clientId to all graphql endpoints to Helix

### DIFF
--- a/app/Base/Page/index.tsx
+++ b/app/Base/Page/index.tsx
@@ -15,6 +15,7 @@ import DisasterWidget, { Props as DisasterWidgetProps } from '#views/DisasterWid
 import IduWidget from '#views/IduWidget';
 import {
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
 } from '#utils/common';
 import {
     GiddYearQuery,
@@ -24,9 +25,11 @@ import {
 const GIDD_YEAR = gql`
     query GiddYear(
         $releaseEnvironment: String!,
+        $clientId: String!,
     ){
         giddYear(
             releaseEnvironment: $releaseEnvironment,
+            clientId: $clientId,
         ) {
             year
         }
@@ -36,6 +39,7 @@ const GIDD_YEAR = gql`
 function useYear() {
     const variables = useMemo(() => ({
         releaseEnvironment: DATA_RELEASE,
+        clientId: HELIX_CLIENT_ID,
     }), []);
 
     const {

--- a/app/components/FigureAnalysis/index.tsx
+++ b/app/components/FigureAnalysis/index.tsx
@@ -14,6 +14,7 @@ import TextOutput from '#components/TextOutput';
 import MarkdownViewer from '#components/MarkdownViewer';
 import {
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
 } from '#utils/common';
 import Container from '#components/Container';
 import CollapsibleContent from '#components/CollapsibleContent';
@@ -27,11 +28,13 @@ query GiddCountryPfa(
     $iso3: String!,
     $year: Int!,
     $releaseEnvironment: String!,
+    $clientId: String!,
 ){
     giddPublicFigureAnalysisList(
         iso3: $iso3,
         year: $year,
         releaseEnvironment: $releaseEnvironment,
+        clientId: $clientId,
     ) {
         results {
             id
@@ -80,6 +83,7 @@ function FigureAnalysis(props: Props) {
         iso3,
         year: Number(selectedYear),
         releaseEnvironment: DATA_RELEASE,
+        clientId: HELIX_CLIENT_ID,
     }), [
         selectedYear,
         iso3,

--- a/app/components/IduMap/useIduMap.tsx
+++ b/app/components/IduMap/useIduMap.tsx
@@ -47,7 +47,7 @@ const IDU_DATA = gql`
             type: "[IduData]",
             method: "GET",
             endpoint: "helix",
-            path: "/idus?client_id={args.clientId}"
+            path: "idus/last-180-days/?client_id={args.clientId}"
         ) {
             id
             country

--- a/app/views/ConflictWidget/index.tsx
+++ b/app/views/ConflictWidget/index.tsx
@@ -34,6 +34,7 @@ import {
     suffixDrupalEndpoint,
     suffixHelixRestEndpoint,
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
     prepareUrl,
 } from '#utils/common';
 import {
@@ -52,8 +53,20 @@ const chartMargins = { top: 16, left: 5, right: 5, bottom: 5 };
 const giddDisplacementDataLink = suffixDrupalEndpoint('/database/displacement-data');
 
 const STATS = gql`
-    query ConflictStats($iso3: String!, $startYear: Float, $endYear: Float, $releaseEnvironment: String!) {
-        giddConflictStatistics(countriesIso3: [$iso3], endYear: $endYear, startYear: $startYear, releaseEnvironment: $releaseEnvironment) {
+    query ConflictStats(
+        $iso3: String!,
+        $startYear: Float,
+        $endYear: Float,
+        $releaseEnvironment: String!,
+        $clientId: String!,
+    ) {
+        giddConflictStatistics(
+            countriesIso3: [$iso3],
+            endYear: $endYear,
+            startYear: $startYear,
+            releaseEnvironment: $releaseEnvironment,
+            clientId: $clientId,
+        ) {
             newDisplacementsRounded
             totalDisplacementsRounded
         }
@@ -61,8 +74,20 @@ const STATS = gql`
 `;
 
 const CONFLICT_DATA = gql`
-    query ConflictData($countryIso3: String!, $startYear: Float, $endYear: Float, $releaseEnvironment: String!) {
-        giddConflictStatistics(countriesIso3: [$countryIso3], endYear: $endYear, startYear: $startYear, releaseEnvironment: $releaseEnvironment) {
+    query ConflictData(
+        $countryIso3: String!,
+        $startYear: Float,
+        $endYear: Float,
+        $releaseEnvironment: String!,
+        $clientId: String!,
+    ) {
+        giddConflictStatistics(
+            countriesIso3: [$countryIso3],
+            endYear: $endYear,
+            startYear: $startYear,
+            releaseEnvironment: $releaseEnvironment,
+            clientId: $clientId,
+        ) {
             newDisplacementsRounded
             totalDisplacementsRounded
             totalDisplacementTimeseriesByYear {
@@ -102,6 +127,7 @@ function ConflictWidget(props: Props) {
                 startYear: START_YEAR,
                 endYear: year,
                 releaseEnvironment: DATA_RELEASE,
+                clientId: HELIX_CLIENT_ID,
             },
             context: {
                 clientName: 'helix',
@@ -123,6 +149,7 @@ function ConflictWidget(props: Props) {
                 startYear: conflictTimeRange[0],
                 endYear: conflictTimeRange[1],
                 releaseEnvironment: DATA_RELEASE,
+                clientId: HELIX_CLIENT_ID,
             },
             context: {
                 clientName: 'helix',

--- a/app/views/DisasterWidget/index.tsx
+++ b/app/views/DisasterWidget/index.tsx
@@ -38,6 +38,7 @@ import {
     suffixDrupalEndpoint,
     suffixHelixRestEndpoint,
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
     getHazardTypeLabel,
     prepareUrl,
 } from '#utils/common';
@@ -68,8 +69,20 @@ const categoricalColorScheme = [
 ];
 
 const STATS = gql`
-    query DisasterStats($iso3: String!, $startYear: Float, $endYear: Float, $releaseEnvironment: String!) {
-        giddDisasterStatistics(countriesIso3: [$iso3], endYear: $endYear, startYear: $startYear, releaseEnvironment: $releaseEnvironment) {
+    query DisasterStats(
+        $iso3: String!,
+        $startYear: Float,
+        $endYear: Float,
+        $releaseEnvironment: String!,
+        $clientId: String!,
+    ) {
+        giddDisasterStatistics(
+            countriesIso3: [$iso3],
+            endYear: $endYear,
+            startYear: $startYear,
+            releaseEnvironment: $releaseEnvironment,
+            clientId: $clientId,
+        ) {
             newDisplacementsRounded
             displacementsByHazardType {
                 id
@@ -81,8 +94,22 @@ const STATS = gql`
 `;
 
 const DISASTER_DATA = gql`
-    query DisasterData($countryIso3: String!, $startYear: Float, $endYear: Float, $categories: [ID!], $releaseEnvironment: String!) {
-        giddDisasterStatistics(countriesIso3: [$countryIso3], endYear: $endYear, startYear: $startYear, hazardTypes: $categories, releaseEnvironment: $releaseEnvironment) {
+    query DisasterData(
+        $countryIso3: String!,
+        $startYear: Float,
+        $endYear: Float,
+        $categories: [ID!],
+        $releaseEnvironment: String!,
+        $clientId: String!,
+    ) {
+        giddDisasterStatistics(
+            countriesIso3: [$countryIso3],
+            endYear: $endYear,
+            startYear: $startYear,
+            hazardTypes: $categories,
+            releaseEnvironment: $releaseEnvironment,
+            clientId: $clientId,
+        ) {
             newDisplacementsRounded
             totalEvents
             newDisplacementTimeseriesByYear {
@@ -124,6 +151,7 @@ function DisasterWidget(props: Props) {
                 startYear: START_YEAR,
                 endYear: year,
                 releaseEnvironment: DATA_RELEASE,
+                clientId: HELIX_CLIENT_ID,
             },
             context: {
                 clientName: 'helix',
@@ -145,6 +173,7 @@ function DisasterWidget(props: Props) {
                 endYear: disasterTimeRange[1],
                 categories: disasterTypes,
                 releaseEnvironment: DATA_RELEASE,
+                clientId: HELIX_CLIENT_ID,
             },
             context: {
                 clientName: 'helix',

--- a/app/views/Gidd/DataTable/index.tsx
+++ b/app/views/Gidd/DataTable/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@togglecorp/toggle-ui';
 import {
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
 } from '#utils/common';
 import {
     gql,
@@ -43,6 +44,7 @@ const GIDD_DISPLACEMENTS = gql`
         $countriesIso3: [String!],
         $releaseEnvironment: String!,
         $cause: String,
+        $clientId: String!,
     ){
         giddDisplacements(
             ordering: $ordering,
@@ -53,6 +55,7 @@ const GIDD_DISPLACEMENTS = gql`
             page: $page,
             releaseEnvironment: $releaseEnvironment,
             cause: $cause,
+            clientId: $clientId,
         ){
             results {
                 conflictNewDisplacementRounded
@@ -110,6 +113,7 @@ function DataTable(props: Props) {
         pageSize: DISPLACEMENTS_TABLE_PAGE_SIZE,
         releaseEnvironment: DATA_RELEASE,
         cause,
+        clientId: HELIX_CLIENT_ID,
     }), [
         countriesIso3,
         startYear,

--- a/app/views/Gidd/EventTitle/Modal/index.tsx
+++ b/app/views/Gidd/EventTitle/Modal/index.tsx
@@ -20,6 +20,7 @@ import NumberBlock from '#components/NumberBlock';
 import Message from '#components/Message';
 import {
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
 } from '#utils/common';
 import {
     GiddEventDetailsQuery,
@@ -32,10 +33,12 @@ const GIDD_EVENT_DETAILS = gql`
 query GiddEventDetails(
     $eventId: ID!,
     $releaseEnvironment: String,
+    $clientId: String!,
 ){
     giddEvent(
         eventId: $eventId,
         releaseEnvironment: $releaseEnvironment,
+        clientId: $clientId,
     ) {
         affectedCountries {
             countryName
@@ -77,6 +80,7 @@ function EventModal(props: Props) {
     const eventVariables = useMemo(() => ({
         eventId,
         releaseEnvironment: DATA_RELEASE,
+        clientId: HELIX_CLIENT_ID,
     }), [eventId]);
 
     const {

--- a/app/views/Gidd/EventsTable/index.tsx
+++ b/app/views/Gidd/EventsTable/index.tsx
@@ -17,6 +17,7 @@ import { IoSearchOutline } from 'react-icons/io5';
 import {
     getHazardTypeLabel,
     DATA_RELEASE,
+    HELIX_CLIENT_ID,
 } from '#utils/common';
 import {
     gql,
@@ -53,6 +54,7 @@ query GiddEvents(
     $hazardTypes: [ID!],
     $countriesIso3: [String!],
     $releaseEnvironment: String!,
+    $clientId: String!,
 ){
     giddDisasters(
         ordering: $ordering,
@@ -64,6 +66,7 @@ query GiddEvents(
         startYear: $startYear,
         hazardTypes: $hazardTypes,
         releaseEnvironment: $releaseEnvironment,
+        clientId: $clientId,
     ){
         results {
             id
@@ -125,6 +128,7 @@ function EventsTable(props: Props) {
         hazardTypes,
         pageSize: EVENTS_TABLE_PAGE_SIZE,
         releaseEnvironment: DATA_RELEASE,
+        clientId: HELIX_CLIENT_ID,
     }), [
         countriesIso3,
         startYear,

--- a/app/views/Home/index.tsx
+++ b/app/views/Home/index.tsx
@@ -18,6 +18,8 @@ import {
     getConflictWidgetLink,
     getDisasterWidgetLink,
     getIduWidgetLink,
+
+    HELIX_REST_ENDPOINT,
 } from '#utils/common';
 
 import styles from './styles.css';
@@ -133,6 +135,14 @@ function Home() {
                     </h2>
                     <a href={getGiddLink()}>
                         Global
+                    </a>
+                </div>
+                <div className={styles.section}>
+                    <h2>
+                        Rest Endpoints
+                    </h2>
+                    <a href={HELIX_REST_ENDPOINT}>
+                        Swagger UI
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Depends on https://github.com/idmc-labs/helix-server/pull/489

## Breaking Change

- Environment variable REACT_APP_HELIX_REST_ENDPOINT should have a trailing slash

## Changes

- Add link to Swagger UI
- Pass clientId to all graphql endpoints to Helix

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] codegen errors
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments
- [ ] conflict markers
