### PR TITLE
Add Shorthand property in country page

### DIFF
--- a/app/views/CountryProfile/index.tsx
+++ b/app/views/CountryProfile/index.tsx
@@ -48,6 +48,7 @@ import styles from './styles.css';
 const contentTypeLabelMapping: {
     [key: string]: string,
 } = {
+    shorthand: 'Shorthand',
     media_centre: 'Media Centre',
     events: 'Events',
     expert_opinion: 'Expert Opinion',


### PR DESCRIPTION
## Addresses:
- Add "Shorthand" line at the country page for country labeling  

## Changes:
- Add a line describing the shorthand property in country section

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
