### PR TITLE
Use _parent for gidd link in IduMap

### DIFF
--- a/app/components/IduMap/useIduMap.tsx
+++ b/app/components/IduMap/useIduMap.tsx
@@ -281,6 +281,7 @@ function useIduQuery(
                 <ButtonLikeLink
                     href={giddLink}
                     className={styles.disasterButton}
+                    target="_parent"
                     icons={(
                         <IoExitOutline />
                     )}


### PR DESCRIPTION
- Addresses Issue with the link not working inside iframe for idupmap

## Changes

- Use _parent for gidd link in IduMap
- The page is used under iframe in idmc website

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers