### PR TITLE
Change tooltip and add validation for year greater than 2022

### DIFF
--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -236,3 +236,20 @@ export function getMaximum<T>(
         return acc;
     }, list[0]);
 }
+
+export function isDisaggregationAvailable(args: {
+    filterStartYear: number,
+    filterEndYear: number,
+    giddYear: number,
+}) {
+    const {
+        filterStartYear,
+        filterEndYear,
+        giddYear,
+    } = args;
+    return (
+        filterStartYear === filterEndYear
+        && filterStartYear === giddYear
+        && giddYear >= 2023
+    );
+}

--- a/app/views/ConflictWidget/index.tsx
+++ b/app/views/ConflictWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
     gql,
     useQuery,
@@ -36,6 +36,7 @@ import {
     suffixHelixRestEndpoint,
     DATA_RELEASE,
     prepareUrl,
+    isDisaggregationAvailable,
 } from '#utils/common';
 import {
     ConflictDataQuery,
@@ -115,20 +116,11 @@ function ConflictWidget(props: Props) {
     const [conflictTimeRangeActual, setConflictTimeRange] = useState([START_YEAR, year]);
     const conflictTimeRange = useDebouncedValue(conflictTimeRangeActual);
 
-    const isSelectedGiddYear = useMemo(
-        () => {
-            if (
-                (conflictTimeRangeActual[0] === year && conflictTimeRangeActual[1] === year)
-                && year >= 2023
-            ) {
-                return true;
-            }
-            return false;
-        }, [
-            conflictTimeRangeActual,
-            year,
-        ],
-    );
+    const disaggregationAvailable = isDisaggregationAvailable({
+        filterStartYear: conflictTimeRangeActual[0],
+        filterEndYear: conflictTimeRangeActual[1],
+        giddYear: year,
+    });
 
     const {
         previousData: previousStatsData,
@@ -254,7 +246,7 @@ function ConflictWidget(props: Props) {
                             target="_blank"
                             rel="noopener noreferrer"
                             transparent
-                            disabled={!isSelectedGiddYear}
+                            disabled={!disaggregationAvailable}
                             actions={(
                                 <IoInformationCircleOutline
                                     title={`${year} Conflict disaggregated caseloads`}
@@ -272,13 +264,13 @@ function ConflictWidget(props: Props) {
                             {`Conflict disaggregated data ${year} (.xlsx)`}
                         </ButtonLikeLink>
                         <ButtonLikeLink
-                            disabled={!isSelectedGiddYear}
+                            disabled={!disaggregationAvailable}
                             target="_blank"
                             rel="noopener noreferrer"
                             transparent
                             actions={(
                                 <IoInformationCircleOutline
-                                    title={`IMPORTANT: Please read the metadata in the ${year} disaggregated caseloads (geojson) formatted for GIS applications. `}
+                                    title={`${year} Conflict disaggregated caseloads (geojson) formatted for GIS applications.\nIMPORTANT: Please read the metadata in the geojson`}
                                 />
                             )}
                             href={suffixHelixRestEndpoint(prepareUrl(

--- a/app/views/ConflictWidget/index.tsx
+++ b/app/views/ConflictWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
     gql,
     useQuery,
@@ -114,6 +114,21 @@ function ConflictWidget(props: Props) {
 
     const [conflictTimeRangeActual, setConflictTimeRange] = useState([START_YEAR, year]);
     const conflictTimeRange = useDebouncedValue(conflictTimeRangeActual);
+
+    const isSelectedGiddYear = useMemo(
+        () => {
+            if (
+                (conflictTimeRangeActual[0] === year && conflictTimeRangeActual[1] === year)
+                && year >= 2023
+            ) {
+                return true;
+            }
+            return false;
+        }, [
+            conflictTimeRangeActual,
+            year,
+        ],
+    );
 
     const {
         previousData: previousStatsData,
@@ -239,6 +254,7 @@ function ConflictWidget(props: Props) {
                             target="_blank"
                             rel="noopener noreferrer"
                             transparent
+                            disabled={!isSelectedGiddYear}
                             actions={(
                                 <IoInformationCircleOutline
                                     title={`${year} Conflict disaggregated caseloads`}
@@ -256,12 +272,13 @@ function ConflictWidget(props: Props) {
                             {`Conflict disaggregated data ${year} (.xlsx)`}
                         </ButtonLikeLink>
                         <ButtonLikeLink
+                            disabled={!isSelectedGiddYear}
                             target="_blank"
                             rel="noopener noreferrer"
                             transparent
                             actions={(
                                 <IoInformationCircleOutline
-                                    title={`${year} Conflict disaggregated caseloads formatted for GIS applications`}
+                                    title={`IMPORTANT: Please read the metadata in the ${year} disaggregated caseloads (geojson) formatted for GIS applications. `}
                                 />
                             )}
                             href={suffixHelixRestEndpoint(prepareUrl(

--- a/app/views/DisasterWidget/index.tsx
+++ b/app/views/DisasterWidget/index.tsx
@@ -40,6 +40,7 @@ import {
     DATA_RELEASE,
     getHazardTypeLabel,
     prepareUrl,
+    isDisaggregationAvailable,
 } from '#utils/common';
 import {
     DisasterDataQuery,
@@ -138,20 +139,11 @@ function DisasterWidget(props: Props) {
     const [disasterTimeRangeActual, setDisasterTimeRange] = useState([START_YEAR, year]);
     const disasterTimeRange = useDebouncedValue(disasterTimeRangeActual);
 
-    const isSelectedGiddYear = useMemo(
-        () => {
-            if (
-                (disasterTimeRangeActual[0] === year && disasterTimeRangeActual[1] === year)
-                && year >= 2023
-            ) {
-                return true;
-            }
-            return false;
-        }, [
-            disasterTimeRangeActual,
-            year,
-        ],
-    );
+    const disaggregationAvailable = isDisaggregationAvailable({
+        filterStartYear: disasterTimeRangeActual[0],
+        filterEndYear: disasterTimeRangeActual[1],
+        giddYear: year,
+    });
 
     const {
         previousData: previousStatsData,
@@ -268,7 +260,7 @@ function DisasterWidget(props: Props) {
                             rel="noopener noreferrer"
                             transparent
                             compact
-                            disabled={!isSelectedGiddYear}
+                            disabled={!disaggregationAvailable}
                             actions={(
                                 <IoInformationCircleOutline
                                     title={`${year} Disaster disaggregated caseloads`}
@@ -291,10 +283,10 @@ function DisasterWidget(props: Props) {
                             rel="noopener noreferrer"
                             transparent
                             compact
-                            disabled={!isSelectedGiddYear}
+                            disabled={!disaggregationAvailable}
                             actions={(
                                 <IoInformationCircleOutline
-                                    title={`IMPORTANT: Please read the metadata in the ${year} disaggregated caseloads (geojson) formatted for GIS applications. `}
+                                    title={`${year} Disaster events disaggregated caseloads (geojson) formatted for GIS applications.\nIMPORTANT: Please read the metadata in the geojson`}
                                 />
                             )}
                             href={suffixHelixRestEndpoint(prepareUrl(

--- a/app/views/DisasterWidget/index.tsx
+++ b/app/views/DisasterWidget/index.tsx
@@ -138,6 +138,21 @@ function DisasterWidget(props: Props) {
     const [disasterTimeRangeActual, setDisasterTimeRange] = useState([START_YEAR, year]);
     const disasterTimeRange = useDebouncedValue(disasterTimeRangeActual);
 
+    const isSelectedGiddYear = useMemo(
+        () => {
+            if (
+                (disasterTimeRangeActual[0] === year && disasterTimeRangeActual[1] === year)
+                && year >= 2023
+            ) {
+                return true;
+            }
+            return false;
+        }, [
+            disasterTimeRangeActual,
+            year,
+        ],
+    );
+
     const {
         previousData: previousStatsData,
         data: statsData = previousStatsData,
@@ -253,6 +268,7 @@ function DisasterWidget(props: Props) {
                             rel="noopener noreferrer"
                             transparent
                             compact
+                            disabled={!isSelectedGiddYear}
                             actions={(
                                 <IoInformationCircleOutline
                                     title={`${year} Disaster disaggregated caseloads`}
@@ -275,9 +291,10 @@ function DisasterWidget(props: Props) {
                             rel="noopener noreferrer"
                             transparent
                             compact
+                            disabled={!isSelectedGiddYear}
                             actions={(
                                 <IoInformationCircleOutline
-                                    title={`${year} Disaster disaggregated caseloads formatted for GIS applications`}
+                                    title={`IMPORTANT: Please read the metadata in the ${year} disaggregated caseloads (geojson) formatted for GIS applications. `}
                                 />
                             )}
                             href={suffixHelixRestEndpoint(prepareUrl(

--- a/app/views/Gidd/index.tsx
+++ b/app/views/Gidd/index.tsx
@@ -25,6 +25,7 @@ import {
     getHazardTypeLabel,
     suffixHelixRestEndpoint,
     prepareUrl,
+    isDisaggregationAvailable,
 } from '#utils/common';
 import {
     gql,
@@ -869,20 +870,11 @@ function Gidd(props: Props) {
         [disasterStats?.displacementsByHazardType],
     );
 
-    const isSelectedGiddYear = useMemo(
-        () => {
-            if (
-                (timeRange[0] === endYear && timeRange[1] === endYear)
-                && endYear >= 2023
-            ) {
-                return true;
-            }
-            return false;
-        }, [
-            timeRange,
-            endYear,
-        ],
-    );
+    const disaggregationAvailable = isDisaggregationAvailable({
+        filterStartYear: timeRange[0],
+        filterEndYear: timeRange[1],
+        giddYear: endYear,
+    });
 
     const maxDisplacementValue = sortedHazards[0]?.newDisplacementsRounded ?? undefined;
 
@@ -996,7 +988,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Disaggregated caseloads`}
@@ -1014,10 +1006,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
+                                                        title={`${endYear} Disaggregated caseloads (geojson) formatted for GIS applications.\nIMPORTANT: Please read the metadata in the geojson`}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(
@@ -1059,7 +1051,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Conflict disaggregated caseloads`}
@@ -1082,10 +1074,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
+                                                        title={`${endYear} Conflict disaggregated caseloads (geojson) formatted for GIS applications.\nIMPORTANT: Please read the metadata in the geojson`}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(prepareUrl(
@@ -1134,7 +1126,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Disaster disaggregated caseloads`}
@@ -1157,10 +1149,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
-                                                disabled={!isSelectedGiddYear}
+                                                disabled={!disaggregationAvailable}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
+                                                        title={`${endYear} Disaster events disaggregated caseloads (geojson) formatted for GIS applications.\nIMPORTANT: Please read the metadata in the geojson`}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(prepareUrl(

--- a/app/views/Gidd/index.tsx
+++ b/app/views/Gidd/index.tsx
@@ -869,6 +869,21 @@ function Gidd(props: Props) {
         [disasterStats?.displacementsByHazardType],
     );
 
+    const isSelectedGiddYear = useMemo(
+        () => {
+            if (
+                (timeRange[0] === endYear && timeRange[1] === endYear)
+                && endYear >= 2023
+            ) {
+                return true;
+            }
+            return false;
+        }, [
+            timeRange,
+            endYear,
+        ],
+    );
+
     const maxDisplacementValue = sortedHazards[0]?.newDisplacementsRounded ?? undefined;
 
     const handleAdditionalFiltersChange = useCallback((newVal) => {
@@ -981,6 +996,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Disaggregated caseloads`}
@@ -998,9 +1014,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`${endYear} Disaggregated caseloads formatted for GIS applications`}
+                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(
@@ -1042,6 +1059,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Conflict disaggregated caseloads`}
@@ -1064,9 +1082,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`${endYear} Conflict disaggregated caseloads formatted for GIS applications`}
+                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(prepareUrl(
@@ -1115,6 +1134,7 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
                                                         title={`${endYear} Disaster disaggregated caseloads`}
@@ -1137,9 +1157,10 @@ function Gidd(props: Props) {
                                             <ButtonLikeLink
                                                 transparent
                                                 compact
+                                                disabled={!isSelectedGiddYear}
                                                 actions={(
                                                     <IoInformationCircleOutline
-                                                        title={`${endYear} Disaster disaggregated caseloads formatted for GIS applications`}
+                                                        title={`IMPORTANT: Please read the metadata in the ${endYear} disaggregated caseloads (geojson) formatted for GIS applications. `}
                                                     />
                                                 )}
                                                 href={suffixHelixRestEndpoint(prepareUrl(


### PR DESCRIPTION
## Addresses

- https://github.com/idmc-labs/helix2.0-meta/issues/1105#issuecomment-2095272597

## Changes

- Change the tooltip in the disaggregated geojson download

- Add validation to show download only for the year greater than 2022


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
